### PR TITLE
addons: add RiMusic and make it optional

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -262,6 +262,12 @@ PRODUCT_PACKAGES += \
     NavbarSammyOverlay \
     NavbarTecnoCamonOverlay
 
+# Prebuilt packages
+ifeq ($(TARGET_INCLUDE_RIMUSIC),true)
+PRODUCT_PACKAGES += \
+    RiMusic
+endif
+
 # Signal Icons
 PRODUCT_PACKAGES += \
     AquariumSignalOverlay \

--- a/prebuilt/product/app/RiMusic/Android.bp
+++ b/prebuilt/product/app/RiMusic/Android.bp
@@ -1,0 +1,12 @@
+android_app_import {
+    name: "RiMusic",
+    apk: "RiMusic.apk",
+    presigned: true,
+    preprocessed: true,
+    product_specific: true,
+    skip_preprocessed_apk_checks: true,
+    overrides: ["Eleven"],
+    dex_preopt: {
+        enabled: false,
+    },
+}


### PR DESCRIPTION
to include in rom, add
TARGET_INCLUDE_RIMUSIC := true
in your device tree

taken and adapted from https://github.com/fast4x/RiMusic version v0.6.51